### PR TITLE
Fixes for location-related functions

### DIFF
--- a/src/Clang/FFI.gc
+++ b/src/Clang/FFI.gc
@@ -21,6 +21,7 @@ module Clang.FFI
 ,SourceRange
 ,getNullRange
 ,getRange
+,getExpansionLocation
 ,getInstantiationLocation
 ,getSpellingLocation
 ,getRangeStart
@@ -361,6 +362,17 @@ data SourceRange = SourceRange (Ptr ()) (Ptr ()) Int Int
 %     CXSourceLocation m = {{p12, p22}, d2};
 %     CXSourceRange r = clang_getRange(l, m);
 %result (sourceRange {r.ptr_data[0]} {r.ptr_data[1]} {r.begin_int_data} {r.end_int_data})
+
+-- void clang_getExpansionLocation(CXSourceLocation location,
+--                                                CXFile *file,
+--                                                unsigned *line,
+--                                                unsigned *column,
+--                                                unsigned *offset);
+%fun clang_getExpansionLocation :: SourceLocation -> IO (Maybe File, Int, Int, Int)
+%call (sourceLocation p1 p2 d)
+%code CXSourceLocation l = {{p1, p2}, d};
+%     CXFile f;unsigned ln,c,o;clang_getExpansionLocation(l,&f,&ln,&c,&o);
+%result (<from_Maybe_File/to_Maybe_File> (file f), (int ln), (int c), (int o))
 
 -- void clang_getInstantiationLocation(CXSourceLocation location,
 --                                                    CXFile *file,

--- a/src/Clang/Source.hs
+++ b/src/Clang/Source.hs
@@ -10,6 +10,7 @@ module Clang.Source
 ,FFI.SourceRange
 ,nullRange
 ,getRange
+,getExpansionLocation
 ,getInstantiationLocation
 ,getSpellingLocation
 ,getStart
@@ -37,6 +38,7 @@ getLocationForOffset tu f off = unsafePerformIO (FFI.getLocationForOffset tu f o
 -- Range functions
 nullRange = unsafePerformIO FFI.getNullRange
 getRange from to = unsafePerformIO (FFI.getRange from to)
+getExpansionLocation = unsafePerformIO . FFI.getExpansionLocation
 getInstantiationLocation = unsafePerformIO . FFI.getInstantiationLocation
 getSpellingLocation = unsafePerformIO . FFI.getSpellingLocation
 getStart = unsafePerformIO . FFI.getRangeStart


### PR DESCRIPTION
This pull request fixes a couple of issues related to the location functions:
- CXFile is itself a pointer, and the CXFile returned by clang_getInstantiationLocation and clang_getSpellingLocation could be null. Since the constructor for File wasn't exported, there was no way for the caller to check for this - you'd just end up with a segfault if you tried to do anything with the return value. I've addressed this by making those functions return a Maybe File instead of a File.
- There was no existing binding for clang_getExpansionLocation. I've added one.

(Sorry for closing and re-requesting; still figuring out the GitHub workflow.)
