### PR TITLE
Fix misuse of ForeignPtrs that caused corruption in code using CXString

### DIFF
--- a/src/Clang/FFI.gc
+++ b/src/Clang/FFI.gc
@@ -254,10 +254,13 @@ unmarshall_cxString p = CXString <$> (newForeignPtr freeStrObj p)
 marshall_cxString :: CXString -> IO (ForeignPtr StringObj)
 marshall_cxString (CXString a) = return a
 
+getCString :: CXString -> IO String
+getCString (CXString fp) = withForeignPtr fp getCString_Ptr
+
 -- const char *clang_getCString(CXString string);
-%fun clang_getCString :: CXString -> IO String
-%call (cxString (fptr (ptr d)))
-%code r = clang_getCString(*(CXString*)d);
+%fun clang_getCString_Ptr :: Ptr StringObj -> IO String
+%call (ptr d)
+%code r = (char*) clang_getCString(*(CXString*)d);
 %result (string r)
 
 -- typedef void *CXFile;
@@ -1808,25 +1811,37 @@ foreign import ccall safe "FFI_stub_ffi.h prim_visitChildren_" prim_visitChildre
 %code CXString *r = mkStrObj();*r = clang_constructUSR_ObjCProtocol(s);
 %result (cxString (ptr r))
 
+constructUSR_ObjCIvar :: String -> CXString -> IO CXString
+constructUSR_ObjCIvar s (CXString fp) =
+  withForeignPtr fp (constructUSR_ObjCIvar_Ptr s)
+
 -- CXString clang_constructUSR_ObjCIvar(const char *name,
 --                                                     CXString classUSR);
-%fun clang_constructUSR_ObjCIvar :: String -> CXString -> IO CXString
-%call (string s) (cxString (fptr (ptr x)))
+%fun clang_constructUSR_ObjCIvar_Ptr :: String -> Ptr StringObj -> IO CXString
+%call (string s) (ptr x)
 %code CXString *r = mkStrObj();*r = clang_constructUSR_ObjCIvar(s, *(CXString *)x);
 %result (cxString (ptr r))
+
+constructUSR_ObjCMethod :: String -> Bool -> CXString -> IO CXString
+constructUSR_ObjCMethod s b (CXString fp) =
+  withForeignPtr fp (constructUSR_ObjCMethod_Ptr s b)
 
 -- CXString clang_constructUSR_ObjCMethod(const char *name,
 --                                                       unsigned isInstanceMethod,
 --                                                       CXString classUSR);
-%fun clang_constructUSR_ObjCMethod :: String -> Bool -> CXString -> IO CXString
-%call (string s) (bool b) (cxString (fptr (ptr x)))
+%fun clang_constructUSR_ObjCMethod_Ptr :: String -> Bool -> Ptr StringObj -> IO CXString
+%call (string s) (bool b) (ptr x)
 %code CXString *r = mkStrObj();*r = clang_constructUSR_ObjCMethod(s, b, *(CXString *)x);
 %result (cxString (ptr r))
 
+constructUSR_ObjCProperty :: String -> CXString -> IO CXString
+constructUSR_ObjCProperty s (CXString fp) =
+  withForeignPtr fp (constructUSR_ObjCProperty_Ptr s)
+
 -- CXString clang_constructUSR_ObjCProperty(const char *property,
 --                                                         CXString classUSR);
-%fun clang_constructUSR_ObjCProperty :: String -> CXString -> IO CXString
-%call (string s) (cxString (fptr (ptr x)))
+%fun clang_constructUSR_ObjCProperty_Ptr :: String -> Ptr StringObj -> IO CXString
+%call (string s) (ptr x)
 %code CXString *r = mkStrObj();*r = clang_constructUSR_ObjCProperty(s, *(CXString *)x);
 %result (cxString (ptr r))
 


### PR DESCRIPTION
The CXString ForeignPtrs were dropping out of scope too soon, causing the finalizer to run and free the strings before callers could actually complete their final action with them. This commit adds wrappers around API calls that take CXStrings as parameters (most importantly clang_getCString, but I covered all the other ones as well) that ensure that the CXString ForeignPtrs stay in scope until they're no longer needed. This resolves the data corruption in the ChildVisitor test.
