### PR TITLE
bindings for {getNumArguments, getArgument, getNumArgTypes, getArgType, ...

### DIFF
--- a/src/Clang/Cursor.hs
+++ b/src/Clang/Cursor.hs
@@ -35,6 +35,8 @@ module Clang.Cursor
 , getSpecializedTemplate
 , getTypeDeclaration
 , getBaseExpression
+, getNumArguments
+, getArgument
 
 -- attribute function
 , getIBOutletCollectionType
@@ -148,6 +150,12 @@ getTypeDeclaration t = liftIO $ FFI.getTypeDeclaration t
 
 getBaseExpression :: FFI.Cursor -> ClangApp s FFI.Cursor
 getBaseExpression c = liftIO $ FFI.cursor_getBaseExpression c
+
+getNumArguments :: FFI.Cursor -> ClangApp s Int
+getNumArguments c = liftIO $ FFI.cursor_getNumArguments c
+
+getArgument :: FFI.Cursor -> Int -> ClangApp s FFI.Cursor
+getArgument c i = liftIO $ FFI.cursor_getArgument c i
 
 -- attribute function
 

--- a/src/Clang/Internal/FFI.gc
+++ b/src/Clang/Internal/FFI.gc
@@ -116,6 +116,8 @@ module Clang.Internal.FFI
 , getEnumDeclIntegerType
 , getEnumConstantDeclValue
 , getEnumConstantDeclUnsignedValue
+, cursor_getNumArguments
+, cursor_getArgument
 , cursor_getBaseExpression
 , equalTypes
 , getCanonicalType
@@ -127,6 +129,9 @@ module Clang.Internal.FFI
 , getDeclObjCTypeEncoding
 , getTypeKindSpelling
 , getResultType
+, getNumArgTypes
+, getArgType
+, isFunctionTypeVariadic
 , getCursorResultType
 , isPODType
 , isVirtualBase
@@ -1799,6 +1804,20 @@ getTypeKind (Type k _ _) = k
 %     r = clang_getEnumConstantDeclUnsignedValue(a);
 %result (word64 r)
 
+-- int clang_Cursor_getNumArguments(CXCursor C);
+%fun clang_cursor_getNumArguments :: Cursor -> IO Int
+%call (cursor k xdata p1 p2 p3)
+%code CXCursor a = {k, xdata, {p1, p2, p3}};
+%     r = clang_Cursor_getNumArguments(a);
+%result (int r)
+
+-- CXCursor clang_Cursor_getArgument(CXCursor C, unsigned i);
+%fun clang_cursor_getArgument :: Cursor -> Int -> IO Cursor
+%call (cursor k xdata p1 p2 p3) (int i)
+%code CXCursor a = {k, xdata, {p1, p2, p3}};
+%     CXCursor r = clang_Cursor_getArgument(a, i);
+%result (cursor {r.kind} {r.xdata} {r.data[0]} {r.data[1]} {r.data[2]})
+
 {-
 -- CXCursor clang_Cursor_getBaseExpression(CXCursor C);
 %fun clang_cursor_getBaseExpression :: Cursor -> IO Cursor
@@ -1885,6 +1904,27 @@ cursor_getBaseExpression = undefined
 %code CXType a = {k, {p1, p2}};
 %     CXType r = clang_getResultType(a);
 %result (type {r.kind} {r.data[0]} {r.data[1]})
+
+-- CXType clang_getNumArgTypes(CXType T);
+%fun clang_getNumArgTypes :: Type -> IO Int
+%call (type k p1 p2)
+%code CXType a = {k, {p1, p2}};
+%     r = clang_getNumArgTypes(a);
+%result (int r)
+
+-- CXType clang_getArgType(CXType T, int i);
+%fun clang_getArgType :: Type -> Int -> IO Type
+%call (type k p1 p2) (int i)
+%code CXType a = {k, {p1, p2}};
+%     CXType r = clang_getArgType(a, i);
+%result (type {r.kind} {r.data[0]} {r.data[1]})
+
+-- unsigned clang_isFunctionTypeVariadic(CXType T);
+%fun clang_isFunctionTypeVariadic :: Type -> IO Bool
+%call (type k p1 p2)
+%code CXType a = {k, {p1, p2}};
+%     r = clang_isFunctionTypeVariadic(a);
+%result (bool r)
 
 -- CXType clang_getCursorResultType(CXCursor C);
 %fun clang_getCursorResultType :: Cursor -> IO Type

--- a/src/Clang/Type.hs
+++ b/src/Clang/Type.hs
@@ -9,6 +9,9 @@ module Clang.Type
 , getCanonicalType
 , getPointeeType
 , getResultType
+, getNumArgTypes
+, getArgType
+, isFunctionTypeVariadic
 
 , getTypedefDeclUnderlyingType
 , getEnumDeclIntegerType
@@ -61,6 +64,15 @@ getPointeeType t = liftIO $ FFI.getPointeeType t
 
 getResultType :: FFI.Type -> ClangApp s FFI.Type
 getResultType t = liftIO $ FFI.getResultType t
+
+getNumArgTypes :: FFI.Type -> ClangApp s Int
+getNumArgTypes t = liftIO $ FFI.getNumArgTypes t
+
+getArgType :: FFI.Type -> Int -> ClangApp s FFI.Type
+getArgType t i = liftIO $ FFI.getArgType t i
+
+isFunctionTypeVariadic :: FFI.Type -> ClangApp s Bool
+isFunctionTypeVariadic t = liftIO $ FFI.isFunctionTypeVariadic t
 
 isConstQualifiedType :: FFI.Type -> ClangApp s Bool
 isConstQualifiedType t = liftIO $ FFI.isConstQualifiedType t


### PR DESCRIPTION
...isFunctionTypeVariadic}

closes #20
