### PR TITLE
"rm -rf build/*" instead of "cd build; rm -rf *" to supress fresh cabal ...

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -97,7 +97,7 @@ libClangBuildHook pkg lbi flags ppHandlers = do
 
 libClangCleanHook pkg v hooks flags = do
     putStrLn "Cleaning llvm and clang..."
-    system $ "cd build && rm -rf *"
+    system $ "rm -rf build/*"
     (cleanHook simpleUserHooks) pkg v hooks flags
 
 escape :: FilePath -> String


### PR DESCRIPTION
...clean causing "/bin/sh: 1: cd: can't cd to build", updates 27429167adcf6d04daff590bf03b9f4b25ed0564
