### PR TITLE
Pull request/packaging with ghc 7.10

### DIFF
--- a/LibClang.cabal
+++ b/LibClang.cabal
@@ -38,14 +38,14 @@ Library
   ghc-options:     -Wall -funbox-strict-fields -O
   build-depends:   base >= 4.6 && < 5,
                    bytestring >= 0.10 && < 0.11,
-                   filepath >= 1.3 && < 1.4,
+                   filepath >= 1.3 && < 1.5,
                    greencard >= 3.0.4 && < 3.1,
                    hashable >= 1.2 && < 1.3,
-                   mtl >= 2.1 && < 2.2,
+                   mtl >= 2.1 && < 2.3,
                    resourcet >= 1.1 && < 1.2,
-                   text >= 1.1 && < 1.2,
-                   time >= 1.4 && < 1.5,
-                   transformers >= 0.3 && < 0.4,
+                   text >= 1.1 && < 1.3,
+                   time >= 1.4 && < 1.6,
+                   transformers >= 0.3 && < 0.5,
                    transformers-base >= 0.4 && < 0.5,
                    vector >= 0.10 && < 0.11
   hs-source-dirs:  src

--- a/Setup.hs
+++ b/Setup.hs
@@ -218,9 +218,10 @@ libClangCopyHook pkg lbi hooks flags = do
   curDir <- getCurrentDirectory
   let llvmLibDir = curDir </> "build" </> "out" </> "lib"
       verbosity = fromFlag (copyVerbosity flags)
-      libCopyDir = libdir $ absoluteInstallDirs pkg lbi NoCopyDest
+      destdir = fromFlagOrDefault NoCopyDest $ copyDest flags
+      libCopyDir = libdir $ absoluteInstallDirs pkg lbi destdir
 
-  notice verbosity "Installing libclang shared libraries..."
+  notice verbosity $ "Installing libclang shared libraries (" ++ show libCopyDir ++ ")..."
   copyFiles verbosity libCopyDir $ map ((llvmLibDir,) . mkSharedLib) libclangSharedLibraries
 
 libClangCleanHook :: PackageDescription -> () -> UserHooks -> CleanFlags -> IO ()


### PR DESCRIPTION
In [Exherbo Linux](http://exherbo.org/) we have only GHC 7.10 and some package have only versions of like `text-1.2.1.1` (see also pull request #52) and `mtl-2.2.1` which is still compatible with {{master}} of LibClang without any changes.
Beside that as in many other linux distros we depend on possibility to files to an image directory that will be later installed in a root dir. In many autotools packages that is known as `DESTDIR` and Cabal also supports that as option [`--destdir` which accessible as CopyDest](http://hackage.haskell.org/package/Cabal-1.22.4.0/docs/Distribution-Simple-Setup.html#t:CopyDest). We need to install `clang` in a same way. I.e. change root path during installation if `--destdir` specified.