### PR TITLE
Convert from Greencard to C2HS.

### DIFF
--- a/LibClang.cabal
+++ b/LibClang.cabal
@@ -36,10 +36,10 @@ Flag preferlibstdcpp
 
 Library
   ghc-options:     -Wall -funbox-strict-fields -O
+  build-tools:     c2hs
   build-depends:   base >= 4.6 && < 5,
                    bytestring >= 0.10 && < 0.11,
                    filepath >= 1.3 && < 1.5,
-                   greencard >= 3.0.4 && < 3.1,
                    hashable >= 1.2 && < 1.3,
                    mtl >= 2.1 && < 2.3,
                    resourcet >= 1.1 && < 1.2,
@@ -49,8 +49,7 @@ Library
                    transformers-base >= 0.4 && < 0.5,
                    vector >= 0.10 && < 0.11
   hs-source-dirs:  src
-  c-sources:       src/Clang/Internal/FFI_stub_ffi.c,
-                   cbits/utils.c,
+  c-sources:       cbits/utils.c,
                    cbits/visitors.c
   include-dirs:    cbits
   exposed-modules: Clang,

--- a/cbits/utils.c
+++ b/cbits/utils.c
@@ -15,3 +15,10 @@ enum CXCursorKind codeCompleteGetResult(CXCodeCompleteResults* results,
   *stringOut = results->Results[index].CompletionString;
   return results->Results[index].CursorKind;
 }
+
+void freeClangString(void* data, unsigned flags) {
+  CXString str;
+  str.data = data;
+  str.private_flags = flags;
+  clang_disposeString(str);
+}

--- a/cbits/utils.h
+++ b/cbits/utils.h
@@ -8,3 +8,5 @@ unsigned codeCompleteGetNumResults(CXCodeCompleteResults* results);
 enum CXCursorKind codeCompleteGetResult(CXCodeCompleteResults* results,
                                         unsigned index,
                                         CXCompletionString* stringOut);
+
+void freeClangString(void* data, unsigned flags);

--- a/src/Clang/Completion.hs
+++ b/src/Clang/Completion.hs
@@ -6,7 +6,7 @@
 --
 -- To get started with code completion, it's enough to parse a file with
 -- 'Clang.parseSourceFile' and pass the 'FFI.TranslationUnit' to 'codeCompleteAt'.
--- This will return a 'FFI.CodeCompleteResults' value, from which you can 
+-- This will return a 'FFI.CodeCompleteResults' value, from which you can
 -- retrieve a list of completion strings using 'getResults'. Each completion
 -- string in turn consists of a series of chunks, which you can retrieve using
 -- 'getChunks'.
@@ -41,7 +41,6 @@ module Clang.Completion
 , getBriefComment
 ) where
 
-import Control.Applicative
 import Control.Monad
 import Control.Monad.IO.Class
 import Data.Typeable
@@ -52,7 +51,7 @@ import qualified Clang.Internal.FFI as FFI
 import Clang.Internal.Monad
 
 -- | Perform code completion at a given location in a translation unit.
--- 
+--
 -- This function performs code completion at a particular file, line, and
 -- column within source code, providing results that suggest potential
 -- code snippets based on the context of the completion. The basic model
@@ -63,7 +62,7 @@ import Clang.Internal.Monad
 -- current location in the C \/ Objective-C \/ C++ grammar and the state of
 -- semantic analysis, what completions to provide. These completions are
 -- returned via a 'FFI.CodeCompleteResults' value.
--- 
+--
 -- Code completion itself is meant to be triggered by the client when the
 -- user types punctuation characters or whitespace, at which point the
 -- code completion location will coincide with the cursor. For example, if \'p\'
@@ -112,7 +111,7 @@ codeCompleteAt t fname l c ufs mayOpts = do
 
 -- | Retrieves a list of code completion results.
 --
--- The first element of each tuple is the completion string, which describes how to insert 
+-- The first element of each tuple is the completion string, which describes how to insert
 -- this result into the editing buffer. Use 'getChunks' to analyze it further.
 --
 -- The second element of each tuple is the kind of entity that this completion refers to.
@@ -191,7 +190,7 @@ getChunks cs = do
 
 -- | Determines the priority of this code completion string.
 --
--- The priority of a code completion indicates how likely it is that this 
+-- The priority of a code completion indicates how likely it is that this
 -- particular completion is the completion that the user will select. The
 -- priority is selected by various internal heuristics. Smaller values
 -- indicate more likely completions.
@@ -211,7 +210,7 @@ getAnnotations cs = do
 
 -- | Retrieves the parent context of the given completion string.
 --
--- The parent context of a completion string is the semantic parent of 
+-- The parent context of a completion string is the semantic parent of
 -- the declaration (if any) that the code completion represents. For example,
 -- a code completion for an Objective-C method would have the method's class
 -- or protocol as its context. A completion string representing a method on

--- a/src/Clang/Cursor.hs
+++ b/src/Clang/Cursor.hs
@@ -85,7 +85,6 @@ module Clang.Cursor
 , getCompletionString
 ) where
 
-import Control.Applicative
 import Control.Monad.IO.Class
 import GHC.Word
 

--- a/src/Clang/Internal/FFIConstants.hsc
+++ b/src/Clang/Internal/FFIConstants.hsc
@@ -22,6 +22,12 @@ module Clang.Internal.FFIConstants
 , offsetCXSourceLocationP1
 , offsetCXSourceLocationP2
 , offsetCXSourceLocationData
+, sizeOfCXSourceRange
+, alignOfCXSourceRange
+, offsetCXSourceRangeP1
+, offsetCXSourceRangeP2
+, offsetCXSourceRangeBegin
+, offsetCXSourceRangeEnd
 , sizeOfCXToken
 , alignOfCXToken
 , offsetCXTokenI1
@@ -93,6 +99,14 @@ alignOfCXSourceLocation = (#const 4) :: Int
 offsetCXSourceLocationP1 = (#const offsetof(CXSourceLocation, ptr_data)) :: Int
 offsetCXSourceLocationP2 = (#const offsetof(CXSourceLocation, ptr_data) + sizeof(void*)) :: Int
 offsetCXSourceLocationData = (#const offsetof(CXSourceLocation, int_data)) :: Int
+
+-- SourceRange constants.
+sizeOfCXSourceRange = (#const sizeof(CXSourceRange)) :: Int
+alignOfCXSourceRange = (#const 4) :: Int
+offsetCXSourceRangeP1 = (#const offsetof(CXSourceRange, ptr_data)) :: Int
+offsetCXSourceRangeP2 = (#const offsetof(CXSourceRange, ptr_data) + sizeof(void*)) :: Int
+offsetCXSourceRangeBegin= (#const offsetof(CXSourceRange, begin_int_data)) :: Int
+offsetCXSourceRangeEnd = (#const offsetof(CXSourceRange, end_int_data) + sizeof(unsigned)) :: Int
 
 -- CXToken constants.
 sizeOfCXToken = (#const sizeof(CXToken)) :: Int

--- a/src/Clang/Internal/Monad.hs
+++ b/src/Clang/Internal/Monad.hs
@@ -20,7 +20,6 @@ module Clang.Internal.Monad
 , mkProxy
 ) where
 
-import Control.Applicative
 import Control.Monad.Base
 import Control.Monad.Trans
 import Control.Monad.Trans.Resource

--- a/src/Clang/TranslationUnit.hs
+++ b/src/Clang/TranslationUnit.hs
@@ -11,7 +11,7 @@
 --
 -- This module is intended to be imported qualified.
 module Clang.TranslationUnit
-( 
+(
 
 -- * Creating a translation unit
   withParsed
@@ -35,7 +35,6 @@ module Clang.TranslationUnit
 
 import Control.Monad.IO.Class
 import Data.Maybe (fromMaybe)
-import Data.Traversable (traverse)
 import qualified Data.Vector as DV
 import System.FilePath ((</>))
 
@@ -129,7 +128,7 @@ iterReparse f tu = do
     ParseComplete finalVal -> return $ Just finalVal
   where
     makeFlags = orFlags . (fromMaybe [FFI.DefaultReparseFlags])
-    
+
 
 -- | A callback for use with 'withReparsing'.
 type ReparsingCallback m r = forall s. FFI.TranslationUnit s

--- a/test/Test_ChildVisitor.hs
+++ b/test/Test_ChildVisitor.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 import System.Environment(getArgs)
 import Control.Monad.IO.Class(liftIO)
 import Text.Printf(printf)

--- a/test/Test_Diagnostics.hs
+++ b/test/Test_Diagnostics.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 import System.Environment(getArgs)
 import Control.Monad.IO.Class(liftIO)
 import Clang.String(unpack)

--- a/test/Test_InclusionVisitor.hs
+++ b/test/Test_InclusionVisitor.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 import System.Environment(getArgs)
 import Control.Monad.IO.Class(liftIO)
 import qualified Data.Vector.Storable as DVS(mapM_)


### PR DESCRIPTION
Hi,
I've fixed most of the errors and of the three tests, two are passing. I was hoping you might help me with the third.

Currently `Test_ChildVisitor_hs` segfaults in the `clang_getTranslationCursorUnit` function (https://github.com/deech/LibClang/blob/master/src/Clang/Internal/FFI.chs#L2578). A debug statement in `clang_getTranslationCursorUnit` tells me that the address of the `CXTranslationUnit` pointer is `0x1`, however a debug statement in the Haskell code before the call prints out a legitimate pointer address. Additionally I printed off the pointer address after the call to `clang_getTranslationUnitCursor` by substituted it with a C function that ignores the pointer argument and just returns a null `CXCursor` and the address is the same legitimate one I had before the call was made.

Currently I'm baffled. The other two passing tests use `getDiagnosticSet` and `getInclusions` both of which do pretty much the same thing but seem to work.

Any help is appreciated.